### PR TITLE
Update Distribution version

### DIFF
--- a/actions/upload.go
+++ b/actions/upload.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 
@@ -26,7 +27,7 @@ func Upload(debug bool) func(c *cli.Context) {
 			log.Fatalf("This command should be called as 'upload $LOCAL_PATH $REMOTE_PATH'")
 		}
 		local := args[0]
-		remote := args[1]
+		remote := fmt.Sprintf("/%s", args[1])
 
 		conf, err := config.FromStorageTypeString(c.GlobalString(config.StorageTypeFlag))
 		if err != nil {

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,8 +2,8 @@ package: github.com/deis/object-storage-cli
 import:
 - package: github.com/codegangsta/cli
 - package: github.com/docker/distribution
-  repo: https://github.com/deis/distribution
-  version: 0afef00d5764404d70f86076f364551657d51de6
+  repo: https://github.com/docker/distribution
+  version: v2.7.1
   vcs: git
   subpackages:
   - registry/storage/driver


### PR DESCRIPTION
This is needed to stop object-storage from trying to create buckets needlessly. 